### PR TITLE
Login cookie fixes

### DIFF
--- a/scripts/shared/userService.js
+++ b/scripts/shared/userService.js
@@ -5,7 +5,9 @@ angular.module('dumboApp')
   var email = null;
   return {
     setLoggedIn : function(userEmail){
-      $cookies.put('email', userEmail);
+      var expiration = new Date();
+      expiration.setDate(expiration.getDate() + 7);
+      $cookies.put('email', userEmail, {'expires':expiration});
     },
     isLoggedIn : function() {
       var c = $cookies.get('email');
@@ -15,7 +17,10 @@ angular.module('dumboApp')
       return $cookies.get('email');
     },
     setLoggedOut: function(userEmail){
-      $cookies.remove('email');
+      var cookies = $cookies.getAll();
+      angular.forEach(cookies, function (v, k) {
+          $cookies.remove(k);
+      });
     }
   }
 });

--- a/scripts/shared/userService.js
+++ b/scripts/shared/userService.js
@@ -6,7 +6,7 @@ angular.module('dumboApp')
   return {
     setLoggedIn : function(userEmail){
       var expiration = new Date();
-      expiration.setDate(expiration.getDate() + 7);
+      expiration.setDate(expiration.getDate() + 6);
       $cookies.put('email', userEmail, {'expires':expiration});
     },
     isLoggedIn : function() {


### PR DESCRIPTION
- Set expiration for cookie to be 6 days (server is 7 days, so front end will request new login early)
- Remove all cookies on logout (only applies to non httpOnly cookies, for security the express token isn't available client side in modern browsers so we rely on the backend to set that)

@brocef 